### PR TITLE
I've added Pest integration tests for your API and Web endpoints.

### DIFF
--- a/tests/Feature/Api/MetricControllerTest.php
+++ b/tests/Feature/Api/MetricControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Metric;
+// Removed: use Illuminate\Foundation\Testing\RefreshDatabase;
+// Removed: use Tests\TestCase;
+// Note: TestCase and RefreshDatabase are typically handled by tests/Pest.php
+
+test('gets metrics list successfully', function () {
+    // Create some metric data using the factory
+    $metrics = Metric::factory()->count(3)->create();
+    $firstMetric = $metrics->first();
+
+    $response = $this->getJson('/api/v1/metrics');
+
+    $response->assertStatus(200)
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [ // '*' means each item in the array
+                    'id',
+                    'action',
+                    'outcome',
+                    'started_at',
+                    'ended_at',
+                    'duration',
+                    'http_request_method',
+                    'client_ip',
+                    'url',
+                    'search_term',
+                    'resource_id',
+                    'http_status_code',
+                    'created_at',
+                    'updated_at',
+                ],
+            ],
+            // No pagination meta expected for this endpoint as per current controller structure
+        ])
+        ->assertJsonCount(3, 'data')
+        ->assertJsonFragment([ // Check if one of the created metric's data is present
+            'action' => $firstMetric->action,
+            'url' => $firstMetric->url,
+        ]);
+});

--- a/tests/Feature/Api/MovieControllerTest.php
+++ b/tests/Feature/Api/MovieControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Services\SWAAPI\Data\MovieDetailDTO;
+use App\Services\SWAAPI\Data\MovieSummaryDTO;
+use App\Services\SWAAPI\Data\PersonSummaryDTO;
+// Removed: use Illuminate\Foundation\Testing\RefreshDatabase;
+// Removed: use Tests\TestCase;
+// Note: TestCase and RefreshDatabase are typically handled by tests/Pest.php
+
+test('gets movies list successfully', function () {
+    $mockClient = $this->mockSWAAPIClient();
+
+    $dummyMovies = [
+        new MovieSummaryDTO(id: 1, title: 'A New Hope', uid: '1', url: 'url/1', characterUrls: ['url/people/1']),
+        new MovieSummaryDTO(id: 2, title: 'The Empire Strikes Back', uid: '2', url: 'url/2', characterUrls: ['url/people/2']),
+    ];
+
+    $mockClient->shouldReceive('getMovies')
+        ->once()
+        ->andReturn($dummyMovies);
+
+    $response = $this->getJson('/api/v1/movies');
+
+    $response->assertStatus(200)
+        ->assertJsonStructure([
+            'data' => [
+                '*' => ['id', 'title', 'uid', 'url', 'character_urls']
+            ]
+        ])
+        ->assertJson([
+            'data' => [
+                ['id' => 1, 'title' => 'A New Hope', 'uid' => '1', 'url' => 'url/1', 'character_urls' => ['url/people/1']],
+                ['id' => 2, 'title' => 'The Empire Strikes Back', 'uid' => '2', 'url' => 'url/2', 'character_urls' => ['url/people/2']],
+            ]
+        ]);
+});
+
+test('gets movie by id successfully', function () {
+    $mockClient = $this->mockSWAAPIClient();
+    $createdTime = now();
+    $editedTime = now();
+
+    $movieDetail = new MovieDetailDTO(
+        id: 1,
+        title: 'A New Hope',
+        director: 'George Lucas',
+        releaseDate: '1977-05-25',
+        openingCrawl: 'It is a period of civil war...',
+        characters: [
+            new PersonSummaryDTO(id: 1, name: 'Luke Skywalker', uid: '1', url: 'url/people/1'),
+        ],
+        properties: [
+            'title' => 'A New Hope',
+            'director' => 'George Lucas',
+            'release_date' => '1977-05-25',
+            'opening_crawl' => 'It is a period of civil war...',
+            // uid is part of the main DTO, not properties
+        ],
+        description: 'A movie from a galaxy far, far away.', // More specific description
+        created: $createdTime->toIso8601String(),
+        edited: $editedTime->toIso8601String(),
+        uid: '1'
+    );
+
+    $mockClient->shouldReceive('getMovieById')
+        ->once()
+        ->with(1)
+        ->andReturn($movieDetail);
+
+    $response = $this->getJson('/api/v1/movies/1');
+
+    $response->assertStatus(200)
+        ->assertJsonStructure([
+            'data' => [
+                'id', 'title', 'director', 'release_date', 'opening_crawl',
+                'characters' => [
+                    '*' => ['id', 'name', 'uid', 'url']
+                ],
+                'properties', 'description', 'created', 'edited', 'uid'
+            ]
+        ])
+        ->assertJson([
+            'data' => [
+                'id' => 1,
+                'title' => 'A New Hope',
+                'director' => 'George Lucas',
+                'release_date' => '1977-05-25',
+                'opening_crawl' => 'It is a period of civil war...',
+                'characters' => [
+                    ['id' => 1, 'name' => 'Luke Skywalker', 'uid' => '1', 'url' => 'url/people/1'],
+                ],
+                'properties' => [
+                    'title' => 'A New Hope',
+                    'director' => 'George Lucas',
+                    'release_date' => '1977-05-25',
+                    'opening_crawl' => 'It is a period of civil war...',
+                ],
+                'description' => 'A movie from a galaxy far, far away.',
+                'created' => $createdTime->toIso8601String(),
+                'edited' => $editedTime->toIso8601String(),
+                'uid' => '1'
+            ]
+        ]);
+});
+
+test('returns 404 when movie not found', function () {
+    $mockClient = $this->mockSWAAPIClient();
+
+    $mockClient->shouldReceive('getMovieById')
+        ->once()
+        ->with(999) // A non-existent ID
+        ->andReturn(null);
+
+    $response = $this->getJson('/api/v1/movies/999');
+
+    $response->assertStatus(404);
+});

--- a/tests/Feature/Api/PeopleControllerTest.php
+++ b/tests/Feature/Api/PeopleControllerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Services\SWAAPI\Data\PaginatedPeopleResponseDTO;
+use App\Services\SWAAPI\Data\PersonDetailDTO;
+use App\Services\SWAAPI\Data\PersonSummaryDTO;
+// Removed: use Illuminate\Foundation\Testing\RefreshDatabase;
+// Removed: use Tests\TestCase;
+// Note: TestCase and RefreshDatabase are typically handled by tests/Pest.php
+
+test('gets people list successfully', function () {
+    $mockClient = $this->mockSWAAPIClient();
+
+    $dummyPeople = [
+        new PersonSummaryDTO(id: 1, name: 'Luke Skywalker', uid: '1', url: 'url/1'),
+        new PersonSummaryDTO(id: 2, name: 'Leia Organa', uid: '2', url: 'url/2'),
+    ];
+
+    $paginatedResponse = new PaginatedPeopleResponseDTO(
+        people: $dummyPeople,
+        currentPage: 1,
+        nextPage: null,
+        perPage: 10,
+        totalRecords: 2,
+        totalPages: 1
+    );
+
+    $mockClient->shouldReceive('getPeople')
+        ->once()
+        ->andReturn($paginatedResponse);
+
+    $response = $this->getJson('/api/v1/people');
+
+    $response->assertStatus(200)
+        ->assertJsonStructure([
+            'data' => [
+                '*' => ['id', 'name', 'uid', 'url']
+            ],
+            'meta' => ['current_page', 'last_page', 'per_page', 'total']
+        ])
+        ->assertJson([
+            'data' => [
+                ['id' => 1, 'name' => 'Luke Skywalker', 'uid' => '1', 'url' => 'url/1'],
+                ['id' => 2, 'name' => 'Leia Organa', 'uid' => '2', 'url' => 'url/2'],
+            ],
+            'meta' => [
+                'current_page' => 1,
+                'last_page' => 1,
+                'per_page' => 10,
+                'total' => 2,
+            ]
+        ]);
+});
+
+test('gets person by id successfully', function () {
+    $mockClient = $this->mockSWAAPIClient();
+
+    $personDetail = new PersonDetailDTO(
+        id: 1,
+        uid: '1',
+        name: 'Luke Skywalker',
+        height: '172',
+        mass: '77',
+        hairColor: 'blond',
+        skinColor: 'fair',
+        eyeColor: 'blue',
+        birthYear: '19BBY',
+        gender: 'male',
+        properties: [
+            'height' => '172',
+            'mass' => '77',
+            'hair_color' => 'blond',
+            'skin_color' => 'fair',
+            'eye_color' => 'blue',
+            'birth_year' => '19BBY',
+            'gender' => 'male',
+        ],
+        description: 'A person',
+        created: now()->toIso8601String(),
+        edited: now()->toIso8601String(),
+        homeworldName: 'Tatooine',
+        homeworldUrl: 'url/tatooine',
+        movies: [
+            ['id' => 1, 'title' => 'A New Hope'],
+        ]
+    );
+
+    $mockClient->shouldReceive('getPersonById')
+        ->once()
+        ->with(1)
+        ->andReturn($personDetail);
+
+    $response = $this->getJson('/api/v1/people/1');
+
+    $response->assertStatus(200)
+        ->assertJsonStructure([
+            'data' => [
+                'id', 'uid', 'name', 'height', 'mass', 'hair_color', 'skin_color',
+                'eye_color', 'birth_year', 'gender', 'properties', 'description',
+                'created', 'edited', 'homeworld_name', 'homeworld_url', 'movies'
+            ]
+        ])
+        ->assertJson([
+            'data' => [
+                'id' => 1,
+                'uid' => '1',
+                'name' => 'Luke Skywalker',
+                'height' => '172',
+                'mass' => '77',
+                'hair_color' => 'blond',
+                'skin_color' => 'fair',
+                'eye_color' => 'blue',
+                'birth_year' => '19BBY',
+                'gender' => 'male',
+                'properties' => [
+                    'height' => '172',
+                    'mass' => '77',
+                    'hair_color' => 'blond',
+                    'skin_color' => 'fair',
+                    'eye_color' => 'blue',
+                    'birth_year' => '19BBY',
+                    'gender' => 'male',
+                ],
+                'description' => 'A person',
+                'created' => $personDetail->created, // Assert against the dynamic value
+                'edited' => $personDetail->edited,   // Assert against the dynamic value
+                'homeworld_name' => 'Tatooine',
+                'homeworld_url' => 'url/tatooine',
+                'movies' => [
+                    ['id' => 1, 'title' => 'A New Hope'],
+                ]
+            ]
+        ]);
+});
+
+test('returns 404 when person not found', function () {
+    $mockClient = $this->mockSWAAPIClient();
+
+    $mockClient->shouldReceive('getPersonById')
+        ->once()
+        ->with(999)
+        ->andReturn(null);
+
+    $response = $this->getJson('/api/v1/people/999');
+
+    $response->assertStatus(404);
+});

--- a/tests/Feature/Http/Controllers/MetricControllerTest.php
+++ b/tests/Feature/Http/Controllers/MetricControllerTest.php
@@ -1,7 +1,55 @@
 <?php
 
-// it('can render the metrics dashboard', function () {
-//     $response = $this->get('/metrics');
-//     $response->assertStatus(200);
-//     $response->assertSee('Filter Metrics');
-// });
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Metric;
+use Inertia\Testing\AssertableInertia;
+// Removed: use Illuminate\Foundation\Testing\RefreshDatabase;
+// Removed: use Tests\TestCase;
+// Note: TestCase and RefreshDatabase are typically handled by tests/Pest.php
+
+test('shows metrics page successfully', function () {
+    // Seed data
+    $metrics = Metric::factory()->count(5)->create();
+    $firstMetric = $metrics->first(); // Get one for specific assertion
+
+    $response = $this->get(route('metrics.index'));
+
+    $response->assertStatus(200);
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Metrics/Index')
+        ->has('metrics') // The prop passed to the view (paginator)
+        ->has('metrics.data', 5) // Check count in paginated data for the current page
+        // Assert structure or specific data of the first item
+        ->where('metrics.data.0.id', $firstMetric->id)
+        ->where('metrics.data.0.action', $firstMetric->action)
+        ->where('metrics.data.0.outcome', $firstMetric->outcome)
+        ->where('metrics.data.0.http_request_method', $firstMetric->http_request_method)
+        ->where('metrics.data.0.client_ip', $firstMetric->client_ip)
+        ->where('metrics.data.0.url', $firstMetric->url)
+        ->where('metrics.data.0.search_term', $firstMetric->search_term)
+        ->where('metrics.data.0.resource_id', $firstMetric->resource_id)
+        ->where('metrics.data.0.http_status_code', $firstMetric->http_status_code)
+        // Asserting the presence of all expected keys for each item in metrics.data
+        ->has('metrics.data', 5, fn (AssertableInertia $item) => $item
+            ->has('id')
+            ->has('action')
+            ->has('outcome')
+            ->has('started_at') // Timestamps are usually present
+            ->has('ended_at')
+            ->has('duration')
+            ->has('http_request_method')
+            ->has('client_ip')
+            ->has('url')
+            ->has('search_term')
+            ->has('resource_id')
+            ->has('http_status_code')
+            ->has('created_at')
+            ->has('updated_at')
+        )
+        ->where('metrics.total', 5) // Total number of metrics
+        ->where('metrics.per_page', 15) // As per controller's pagination
+        ->where('metrics.current_page', 1) // Should be the first page
+    );
+});

--- a/tests/Feature/Http/Controllers/MovieControllerTest.php
+++ b/tests/Feature/Http/Controllers/MovieControllerTest.php
@@ -1,14 +1,84 @@
 <?php
 
-use App\Jobs\CreateMetrics;
+namespace Tests\Feature\Http\Controllers;
 
-it('can list movie 1 - A New Hope', function () {
-    // enable middleware
-    $this->withMiddleware(CreateMetrics::class);
+use App\Services\SWAAPI\Data\MovieDetailDTO;
+use App\Services\SWAAPI\Data\PersonSummaryDTO;
+use Inertia\Testing\AssertableInertia;
+// Removed: use Illuminate\Foundation\Testing\RefreshDatabase;
+// Removed: use Tests\TestCase;
+// Removed: use App\Jobs\CreateMetrics; // As the test using it is redundant
 
-    $response = $this->get('/movies/1');
+test('shows movie page successfully', function () {
+    $mockClient = $this->mockSWAAPIClient();
+    $createdTime = now()->toIso8601String();
+    $editedTime = now()->toIso8601String();
+
+    $movieDetail = new MovieDetailDTO(
+        id: 1,
+        uid: '1', // Added UID as per common DTO structure
+        title: 'A New Hope',
+        director: 'George Lucas',
+        releaseDate: '1977-05-25',
+        openingCrawl: 'It is a period of civil war...',
+        properties: [ // Ensure these properties are what MovieDetailDTO expects in its 'properties' array
+            'title' => 'A New Hope', // It's usually a top-level prop, but following prompt example
+            'director' => 'George Lucas',
+            'release_date' => '1977-05-25',
+            'opening_crawl' => 'It is a period of civil war...',
+            'uid' => '1', // Also usually top-level
+        ],
+        description: 'A Star Wars movie.',
+        created: $createdTime,
+        edited: $editedTime,
+        characters: [
+            new PersonSummaryDTO(id: 1, name: 'Luke Skywalker', uid: '1', url: 'url/luke'),
+            new PersonSummaryDTO(id: 2, name: 'Leia Organa', uid: '2', url: 'url/leia'),
+        ]
+    );
+
+    $mockClient->shouldReceive('getMovieById')
+        ->once()
+        ->with(1)
+        ->andReturn($movieDetail);
+
+    $response = $this->get(route('movies.show', ['id' => 1]));
+
     $response->assertStatus(200);
-    $response->assertSee('A New Hope');
 
-    // dump(Metric::all());
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Movies/Show')
+        ->has('movie')
+        ->where('movie.id', 1)
+        ->where('movie.uid', '1')
+        ->where('movie.title', 'A New Hope')
+        ->where('movie.director', 'George Lucas')
+        ->where('movie.releaseDate', '1977-05-25')
+        ->where('movie.openingCrawl', 'It is a period of civil war...')
+        ->where('movie.description', 'A Star Wars movie.')
+        ->where('movie.created', $createdTime)
+        ->where('movie.edited', $editedTime)
+        // Add more assertions for other properties as needed
+        ->has('movie.characters', 2) // Example for nested prop
+        ->where('movie.characters.0.name', 'Luke Skywalker')
+        ->where('movie.characters.0.uid', '1')
+        ->where('movie.characters.1.name', 'Leia Organa')
+        ->where('movie.characters.1.uid', '2')
+        // Asserting properties within the 'properties' array if applicable
+        ->has('movie.properties')
+        ->where('movie.properties.uid', '1') // Example, adjust if 'uid' is not in DTO's 'properties'
+    );
+});
+
+test('returns 404 when movie page not found', function () {
+    $mockClient = $this->mockSWAAPIClient();
+
+    $mockClient->shouldReceive('getMovieById')
+        ->once()
+        ->with(999)
+        ->andReturn(null);
+
+    $response = $this->get(route('movies.show', ['id' => 999]));
+
+    $response->assertStatus(404);
 });

--- a/tests/Feature/Http/Controllers/PeopleControllerTest.php
+++ b/tests/Feature/Http/Controllers/PeopleControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Services\SWAAPI\Data\PersonDetailDTO;
+use App\Services\SWAAPIClient; // Ensure SWAAPIClient is imported for mocking
+use Inertia\Testing\AssertableInertia;
+// Removed: use Illuminate\Foundation\Testing\RefreshDatabase;
+// Removed: use Tests\TestCase;
+// Note: TestCase and RefreshDatabase are typically handled by tests/Pest.php
+
+test('shows person page successfully', function () {
+    // Mock SWAAPIClient
+    $mockSwaapiClient = $this->mockSWAAPIClient();
+
+    // Create a dummy PersonDetailDTO
+    $personData = new PersonDetailDTO(
+        id: 1,
+        uid: '1',
+        name: 'Luke Skywalker',
+        height: '172',
+        mass: '77',
+        hairColor: 'blond',
+        skinColor: 'fair',
+        eyeColor: 'blue',
+        birthYear: '19BBY',
+        gender: 'male',
+        properties: [
+            'height' => '172',
+            'mass' => '77',
+            'hair_color' => 'blond',
+            'skin_color' => 'fair',
+            'eye_color' => 'blue',
+            'birth_year' => '19BBY',
+            'gender' => 'male',
+            'homeworld' => 'url/tatooine', // Assuming homeworld URL is part of properties
+            'url' => 'https://www.swapi.tech/api/people/1' // Assuming 'url' is part of properties
+        ],
+        description: 'A character from Star Wars.',
+        created: now()->toIso8601String(),
+        edited: now()->toIso8601String(),
+        homeworldName: 'Tatooine',
+        homeworldUrl: 'url/tatooine',
+        movies: [
+            ['id' => 4, 'title' => 'A New Hope'], // Assuming movie IDs might differ from person ID
+            ['id' => 5, 'title' => 'The Empire Strikes Back']
+        ]
+    );
+
+    $mockSwaapiClient->shouldReceive('getPersonById')
+        ->once()
+        ->with(1)
+        ->andReturn($personData);
+
+    // Make a GET request to the web route for showing a person
+    // Assuming the route is named 'people.show' as per web.php
+    $response = $this->get(route('people.show', ['id' => 1]));
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('People/Show')
+        ->has('person')
+        ->where('person.id', 1)
+        ->where('person.name', 'Luke Skywalker')
+        ->where('person.uid', '1') // Ensure uid is asserted
+        ->where('person.height', '172')
+        ->where('person.mass', '77')
+        ->where('person.hairColor', 'blond') // Corrected from hair_color to hairColor to match DTO
+        ->where('person.skinColor', 'fair') // Corrected from skin_color to skinColor
+        ->where('person.eyeColor', 'blue')   // Corrected from eye_color to eyeColor
+        ->where('person.birthYear', '19BBY') // Corrected from birth_year to birthYear
+        ->where('person.gender', 'male')
+        ->where('person.homeworldName', 'Tatooine') // Corrected from homeworld_name to homeworldName
+        ->has('person.movies', 2) // Asserting count of movies
+        ->where('person.movies.0.title', 'A New Hope')
+        ->where('person.movies.1.title', 'The Empire Strikes Back')
+    );
+});
+
+test('returns 404 when person page not found', function () {
+    // Mock SWAAPIClient
+    $mockSwaapiClient = $this->mockSWAAPIClient();
+
+    $mockSwaapiClient->shouldReceive('getPersonById')
+        ->once()
+        ->with(999)
+        ->andReturn(null);
+
+    // Make a GET request to a non-existent person ID
+    $response = $this->get(route('people.show', ['id' => 999]));
+
+    $response->assertStatus(404);
+});

--- a/tests/Feature/WebRoutesTest.php
+++ b/tests/Feature/WebRoutesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Inertia\Testing\AssertableInertia;
+// Removed: use Tests\TestCase;
+// Note: TestCase is typically handled by tests/Pest.php
+
+test('home redirects to dashboard', function () {
+    $response = $this->get('/');
+    $response->assertStatus(302);
+    $response->assertRedirect(route('dashboard'));
+});
+
+test('dashboard renders successfully', function () {
+    // If dashboard requires authentication, this test might need adjustment
+    // by creating a user and using $this->actingAs($user).
+    // For now, assuming it's accessible.
+    $response = $this->get(route('dashboard'));
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Dashboard')
+    );
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,16 @@
 
 namespace Tests;
 
+use App\Services\SWAAPIClient;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Mockery;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    public function mockSWAAPIClient()
+    {
+        $mock = Mockery::mock(SWAAPIClient::class);
+        $this->instance(SWAAPIClient::class, $mock);
+        return $mock;
+    }
 }


### PR DESCRIPTION
This commit introduces a comprehensive suite of integration tests using the Pest testing framework.

Key changes include:

-   **SWAAPI Client Mocking**: I added a helper method to `tests/TestCase.php` to easily mock the `SWAAPIClient`, preventing actual API calls during testing.
-   **API Endpoint Tests**:
    -   I generated Pest tests for `PeopleController`, `MovieController`, and `MetricController` API endpoints.
    -   These tests cover successful data retrieval, handling of not-found scenarios (404s), and correct JSON response structures.
    -   `SWAAPIClient` interactions are mocked.
-   **Web (Inertia) Endpoint Tests**:
    -   I generated Pest tests for the web (Inertia view) counterparts of `PeopleController`, `MovieController`, and `MetricController`.
    -   Tests verify correct Inertia component rendering, prop data (with `SWAAPIClient` mocked), and handling of not-found scenarios.
    -   Tests for basic web routes (`/` redirect and `/dashboard`) are also included.
-   **Refactoring to Pest**: I wrote all newly created tests in Pest syntax. I converted existing PHPUnit-style tests in the affected controller test files to Pest, and removed redundancies.

Note: Due to limitations in my current environment (missing PHP/Composer), I couldn't run the tests automatically. You should verify them in a local Laravel Sail environment.